### PR TITLE
Ignore untiy files

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,7 +1,8 @@
 cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/
-cryptoauthlib/test/*
+cryptoauthlib/test/cmd-processor.c
+cryptoauthlib/test/unity*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*


### PR DESCRIPTION
Ignore unity files, as main application may use its own unity, For example in our mcce mbed-os also compiles untity files.